### PR TITLE
Implement Room cache and update RAWG API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
@@ -17,7 +18,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "API_KEY", "\"${project.property("API_KEY")}\"")
+        buildConfigField("String", "RAWG_KEY", "\"${project.property("API_KEY")}\"")
     }
 
     buildTypes {
@@ -58,11 +59,15 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
     implementation(libs.paging.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
+    implementation(libs.androidx.work.runtime.ktx)
     testImplementation(libs.junit)
     testImplementation(libs.mockwebserver)
     testImplementation(libs.kotlinx.coroutines.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.room.testing)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)

--- a/app/src/androidTest/java/com/example/gamehub/data/local/MigrationTest.kt
+++ b/app/src/androidTest/java/com/example/gamehub/data/local/MigrationTest.kt
@@ -1,0 +1,31 @@
+package com.example.gamehub.data.local
+
+import android.content.Context
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+    private val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java.canonicalName
+    )
+
+    @get:Rule
+    val rule = helper
+
+    @Test
+    fun migrate1To2() {
+        val db = helper.createDatabase("test.db", 1)
+        db.execSQL("CREATE TABLE IF NOT EXISTS games (id INTEGER PRIMARY KEY NOT NULL, name TEXT NOT NULL, backgroundImage TEXT, rating REAL, released TEXT, lastUpdated INTEGER NOT NULL)")
+        db.close()
+
+        helper.runMigrationsAndValidate("test.db", 2, true, MIGRATION_1_2)
+    }
+}

--- a/app/src/main/java/com/example/gamehub/data/NewReleasesRemoteMediator.kt
+++ b/app/src/main/java/com/example/gamehub/data/NewReleasesRemoteMediator.kt
@@ -1,0 +1,66 @@
+package com.example.gamehub.data
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.RemoteMediator
+import androidx.paging.LoadType
+import androidx.paging.PagingState
+import com.example.gamehub.data.local.AppDatabase
+import com.example.gamehub.data.local.GameEntity
+import com.example.gamehub.data.local.RemoteKeysEntity
+import com.example.gamehub.data.remote.RawgApi
+import com.example.gamehub.data.remote.GameDto
+import androidx.room.withTransaction
+import kotlinx.coroutines.delay
+import retrofit2.HttpException
+import java.io.IOException
+
+@OptIn(ExperimentalPagingApi::class)
+class NewReleasesRemoteMediator(
+    private val api: RawgApi,
+    private val db: AppDatabase,
+    private val apiKey: String
+) : RemoteMediator<Int, GameEntity>() {
+
+    override suspend fun load(
+        loadType: LoadType,
+        state: PagingState<Int, GameEntity>
+    ): MediatorResult {
+        val page = when (loadType) {
+            LoadType.REFRESH -> 1
+            LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
+            LoadType.APPEND -> {
+                val lastItem = state.lastItemOrNull()
+                lastItem?.let { last ->
+                    db.remoteKeysDao().remoteKeys(last.id)?.nextKey
+                } ?: 1
+            }
+        } ?: 1
+
+        return try {
+            val response = api.getNewReleases(page = page, apiKey = apiKey)
+            val games = response.body()?.results ?: emptyList()
+
+            db.withTransaction {
+                val entities = games.map { it.toEntity() }
+                val keys = games.map {
+                    RemoteKeysEntity(
+                        gameId = it.id,
+                        prevKey = if (page == 1) null else page - 1,
+                        nextKey = page + 1
+                    )
+                }
+                db.gameDao().insertAll(entities)
+                db.remoteKeysDao().insertAll(keys)
+            }
+
+            MediatorResult.Success(endOfPaginationReached = games.isEmpty())
+        } catch (e: IOException) {
+            MediatorResult.Error(e)
+        } catch (e: HttpException) {
+            MediatorResult.Error(e)
+        }
+    }
+}
+
+private fun GameDto.toEntity(): GameEntity =
+    GameEntity(id, name, backgroundImage, rating, released, System.currentTimeMillis())

--- a/app/src/main/java/com/example/gamehub/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/gamehub/data/local/AppDatabase.kt
@@ -1,0 +1,14 @@
+package com.example.gamehub.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [GameEntity::class, RemoteKeysEntity::class],
+    version = 2,
+    exportSchema = true
+)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun gameDao(): GameDao
+    abstract fun remoteKeysDao(): RemoteKeysDao
+}

--- a/app/src/main/java/com/example/gamehub/data/local/GameDao.kt
+++ b/app/src/main/java/com/example/gamehub/data/local/GameDao.kt
@@ -1,0 +1,16 @@
+package com.example.gamehub.data.local
+
+import androidx.paging.PagingSource
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface GameDao {
+    @Query("SELECT * FROM games ORDER BY released DESC")
+    fun pagingNew(): PagingSource<Int, GameEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(games: List<GameEntity>)
+}

--- a/app/src/main/java/com/example/gamehub/data/local/GameEntity.kt
+++ b/app/src/main/java/com/example/gamehub/data/local/GameEntity.kt
@@ -1,0 +1,14 @@
+package com.example.gamehub.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "games")
+data class GameEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val backgroundImage: String?,
+    val rating: Double?,
+    val released: String?,
+    val lastUpdated: Long,
+)

--- a/app/src/main/java/com/example/gamehub/data/local/Migrations.kt
+++ b/app/src/main/java/com/example/gamehub/data/local/Migrations.kt
@@ -1,0 +1,10 @@
+package com.example.gamehub.data.local
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE games ADD COLUMN metacritic INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/app/src/main/java/com/example/gamehub/data/local/RemoteKeysDao.kt
+++ b/app/src/main/java/com/example/gamehub/data/local/RemoteKeysDao.kt
@@ -1,0 +1,15 @@
+package com.example.gamehub.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface RemoteKeysDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(keys: List<RemoteKeysEntity>)
+
+    @Query("SELECT * FROM remote_keys WHERE gameId = :id")
+    suspend fun remoteKeys(id: Int): RemoteKeysEntity?
+}

--- a/app/src/main/java/com/example/gamehub/data/local/RemoteKeysEntity.kt
+++ b/app/src/main/java/com/example/gamehub/data/local/RemoteKeysEntity.kt
@@ -1,0 +1,11 @@
+package com.example.gamehub.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "remote_keys")
+data class RemoteKeysEntity(
+    @PrimaryKey val gameId: Int,
+    val prevKey: Int?,
+    val nextKey: Int?,
+)

--- a/app/src/main/java/com/example/gamehub/data/remote/GameDto.kt
+++ b/app/src/main/java/com/example/gamehub/data/remote/GameDto.kt
@@ -13,4 +13,5 @@ data class GameDto(
     @SerialName("background_image")
     val backgroundImage: String? = null,
     val rating: Double? = null,
+    val released: String? = null,
 )

--- a/app/src/main/java/com/example/gamehub/data/remote/RawgApi.kt
+++ b/app/src/main/java/com/example/gamehub/data/remote/RawgApi.kt
@@ -14,7 +14,9 @@ interface RawgApi {
     @GET("games")
     suspend fun getNewReleases(
         @Query("ordering") ordering: String = "-released",
-        @Query("key") apiKey: String
+        @Query("page") page: Int,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("key") apiKey: String,
     ): Response<GamesResponse>
 
     /**
@@ -23,6 +25,8 @@ interface RawgApi {
     @GET("games")
     suspend fun getTopRated(
         @Query("ordering") ordering: String = "-rating",
-        @Query("key") apiKey: String
+        @Query("page") page: Int,
+        @Query("page_size") pageSize: Int = 20,
+        @Query("key") apiKey: String,
     ): Response<GamesResponse>
 }

--- a/app/src/test/java/com/example/gamehub/data/remote/RawgApiTest.kt
+++ b/app/src/test/java/com/example/gamehub/data/remote/RawgApiTest.kt
@@ -40,9 +40,9 @@ class RawgApiTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(mockJson))
 
         runBlocking {
-            val response = api.getNewReleases(apiKey = "test")
+            val response = api.getNewReleases(page = 1, apiKey = "test")
             val request = server.takeRequest()
-            assertEquals("/games?ordering=-released&key=test", request.path)
+            assertEquals("/games?ordering=-released&page=1&page_size=20&key=test", request.path)
             assertEquals(1, server.requestCount)
             assertEquals(200, response.code())
             // Assert that response parsed correctly
@@ -56,9 +56,9 @@ class RawgApiTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(mockJson))
 
         runBlocking {
-            val response = api.getTopRated(apiKey = "test")
+            val response = api.getTopRated(page = 1, apiKey = "test")
             val request = server.takeRequest()
-            assertEquals("/games?ordering=-rating&key=test", request.path)
+            assertEquals("/games?ordering=-rating&page=1&page_size=20&key=test", request.path)
             assertEquals(1, server.requestCount)
             assertEquals(200, response.code())
             assertEquals(0, response.body()!!.results.size)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ coroutines = "1.8.1"
 serializationJson = "1.8.1"
 retrofitSerialization = "1.0.0"
 paging = "3.2.1"
+room = "2.6.1"
+work = "2.9.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -38,10 +40,15 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serializationJson" }
 converter-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitSerialization" }
 paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
+androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- setup Room and WorkManager dependencies
- expose RAWG API key as `RAWG_KEY`
- extend `GameDto` with `released`
- update Retrofit interface with paging params
- provide Room cache entities and database with migration
- add remote mediator and related DAO
- adjust unit tests

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew :app:kaptDebugKotlin` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8e3f2fb48328b5473bbeef3bb277