### PR TITLE
Implement repository and sync utilities

### DIFF
--- a/app/src/main/java/com/example/gamehub/data/HomeRepository.kt
+++ b/app/src/main/java/com/example/gamehub/data/HomeRepository.kt
@@ -1,0 +1,46 @@
+package com.example.gamehub.data
+
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.example.gamehub.BuildConfig
+import com.example.gamehub.data.local.AppDatabase
+import com.example.gamehub.data.local.GameDao
+import com.example.gamehub.data.remote.RawgApi
+import com.example.gamehub.domain.Game
+import com.example.gamehub.domain.toDomain
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class HomeRepository(
+    private val api: RawgApi,
+    private val db: AppDatabase,
+    private val gameDao: GameDao = db.gameDao(),
+    private val apiKey: String = BuildConfig.RAWG_KEY,
+) {
+    @OptIn(ExperimentalPagingApi::class)
+    fun newReleases(): Flow<PagingData<Game>> {
+        val mediator = NewReleasesRemoteMediator(api, db, apiKey)
+        return Pager(
+            config = PagingConfig(pageSize = 20),
+            remoteMediator = mediator,
+            pagingSourceFactory = { gameDao.pagingNew() }
+        ).flow.map { pagingData ->
+            pagingData.map { it.toDomain() }
+        }
+    }
+
+    @OptIn(ExperimentalPagingApi::class)
+    fun topRated(): Flow<PagingData<Game>> {
+        val mediator = TopRatedRemoteMediator(api, db, apiKey)
+        return Pager(
+            config = PagingConfig(pageSize = 20),
+            remoteMediator = mediator,
+            pagingSourceFactory = { gameDao.pagingNew() }
+        ).flow.map { pagingData ->
+            pagingData.map { it.toDomain() }
+        }
+    }
+}

--- a/app/src/main/java/com/example/gamehub/data/TopRatedRemoteMediator.kt
+++ b/app/src/main/java/com/example/gamehub/data/TopRatedRemoteMediator.kt
@@ -1,24 +1,23 @@
 package com.example.gamehub.data
 
 import androidx.paging.ExperimentalPagingApi
-import androidx.paging.RemoteMediator
 import androidx.paging.LoadType
 import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import androidx.room.withTransaction
 import com.example.gamehub.data.local.AppDatabase
 import com.example.gamehub.data.local.GameEntity
 import com.example.gamehub.data.local.RemoteKeysEntity
-import com.example.gamehub.data.remote.RawgApi
 import com.example.gamehub.data.remote.GameDto
-import androidx.room.withTransaction
-import kotlinx.coroutines.delay
+import com.example.gamehub.data.remote.RawgApi
 import retrofit2.HttpException
 import java.io.IOException
 
 @OptIn(ExperimentalPagingApi::class)
-class NewReleasesRemoteMediator(
+class TopRatedRemoteMediator(
     private val api: RawgApi,
     private val db: AppDatabase,
-    private val apiKey: String
+    private val apiKey: String,
 ) : RemoteMediator<Int, GameEntity>() {
 
     override suspend fun load(
@@ -29,15 +28,13 @@ class NewReleasesRemoteMediator(
             LoadType.REFRESH -> 1
             LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
             LoadType.APPEND -> {
-                val lastItem = state.lastItemOrNull()
-                lastItem?.let { last ->
-                    db.remoteKeysDao().remoteKeys(last.id)?.nextKey
-                } ?: 1
+                val last = state.lastItemOrNull()
+                last?.let { db.remoteKeysDao().remoteKeys(it.id)?.nextKey } ?: 1
             }
         } ?: 1
 
         return try {
-            val response = api.getNewReleases(page = page, apiKey = apiKey)
+            val response = api.getTopRated(page = page, apiKey = apiKey)
             val games = response.body()?.results ?: emptyList()
 
             db.withTransaction {

--- a/app/src/main/java/com/example/gamehub/data/local/GameDao.kt
+++ b/app/src/main/java/com/example/gamehub/data/local/GameDao.kt
@@ -13,4 +13,10 @@ interface GameDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(games: List<GameEntity>)
+
+    @Query("DELETE FROM games")
+    suspend fun clearAll()
+
+    @Query("DELETE FROM games WHERE lastUpdated < :time")
+    suspend fun deleteOlderThan(time: Long)
 }

--- a/app/src/main/java/com/example/gamehub/data/local/RemoteKeysDao.kt
+++ b/app/src/main/java/com/example/gamehub/data/local/RemoteKeysDao.kt
@@ -12,4 +12,7 @@ interface RemoteKeysDao {
 
     @Query("SELECT * FROM remote_keys WHERE gameId = :id")
     suspend fun remoteKeys(id: Int): RemoteKeysEntity?
+
+    @Query("DELETE FROM remote_keys")
+    suspend fun clearRemoteKeys()
 }

--- a/app/src/main/java/com/example/gamehub/domain/Game.kt
+++ b/app/src/main/java/com/example/gamehub/domain/Game.kt
@@ -1,0 +1,9 @@
+package com.example.gamehub.domain
+
+data class Game(
+    val id: Int,
+    val name: String,
+    val backgroundImage: String?,
+    val rating: Double?,
+    val released: String?,
+)

--- a/app/src/main/java/com/example/gamehub/domain/Mappers.kt
+++ b/app/src/main/java/com/example/gamehub/domain/Mappers.kt
@@ -1,0 +1,5 @@
+package com.example.gamehub.domain
+
+import com.example.gamehub.data.local.GameEntity
+
+fun GameEntity.toDomain(): Game = Game(id, name, backgroundImage, rating, released)

--- a/app/src/main/java/com/example/gamehub/util/NetworkBoundResource.kt
+++ b/app/src/main/java/com/example/gamehub/util/NetworkBoundResource.kt
@@ -1,0 +1,24 @@
+package com.example.gamehub.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.emitAll
+
+suspend fun <T> networkBoundResource(
+    query: () -> Flow<T>,
+    fetch: suspend () -> T,
+    saveFetchResult: suspend (T) -> Unit,
+    shouldFetch: (T) -> Boolean = { true },
+): Flow<T> = flow {
+    val data = query().first()
+    if (shouldFetch(data)) {
+        try {
+            saveFetchResult(fetch())
+        } catch (t: Throwable) {
+            emit(data)
+            throw t
+        }
+    }
+    emitAll(query())
+}

--- a/app/src/main/java/com/example/gamehub/work/CacheCleanWorker.kt
+++ b/app/src/main/java/com/example/gamehub/work/CacheCleanWorker.kt
@@ -1,0 +1,44 @@
+package com.example.gamehub.work
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.example.gamehub.data.local.AppDatabase
+import java.util.concurrent.TimeUnit
+
+class CacheCleanWorker(
+    context: Context,
+    params: WorkerParameters,
+    private val db: AppDatabase,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val cutoff = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(7)
+        db.gameDao().deleteOlderThan(cutoff)
+        return Result.success()
+    }
+
+    companion object {
+        private const val WORK_NAME = "cache_clean"
+
+        fun schedule(context: Context, db: AppDatabase) {
+            val request = PeriodicWorkRequestBuilder<CacheCleanWorker>(1, TimeUnit.DAYS)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.UNMETERED)
+                        .build()
+                )
+                .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/example/gamehub/util/NetworkBoundResourceTest.kt
+++ b/app/src/test/java/com/example/gamehub/util/NetworkBoundResourceTest.kt
@@ -1,0 +1,21 @@
+package com.example.gamehub.util
+
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NetworkBoundResourceTest {
+    @Test
+    fun `offline then fetch`() = runTest {
+        var saved = false
+        val result = networkBoundResource(
+            query = { flowOf("db") },
+            fetch = { "net" },
+            saveFetchResult = { saved = true },
+        )
+        assertEquals(listOf("db", "net"), result.toList())
+        assertEquals(true, saved)
+    }
+}


### PR DESCRIPTION
## Summary
- create a domain `Game` model and mapping helpers
- implement `TopRatedRemoteMediator`
- enhance `NewReleasesRemoteMediator` with clearing logic
- add `HomeRepository` returning paged flows
- provide `NetworkBoundResource` helper
- add `CacheCleanWorker` for daily cleanup
- extend DAOs with clear and delete methods
- add basic unit test for `NetworkBoundResource`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cd9119448328b57c3c13cfa93b66