### PR TITLE
Implement offline UI indicator

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.pullrefresh)
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
     implementation(libs.converter.serialization)

--- a/app/src/main/java/com/example/gamehub/MainActivity.kt
+++ b/app/src/main/java/com/example/gamehub/MainActivity.kt
@@ -4,14 +4,14 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.example.gamehub.ui.theme.GameHubTheme
+import com.example.gamehub.ui.HomeScreen
+import com.example.gamehub.ui.HomeViewModel
+import com.example.gamehub.util.NetworkManager
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,29 +19,18 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             GameHubTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                val viewModel: HomeViewModel by viewModels {
+                    object : androidx.lifecycle.ViewModelProvider.Factory {
+                        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+                            @Suppress("UNCHECKED_CAST")
+                            return HomeViewModel(NetworkManager(applicationContext)) as T
+                        }
+                    }
+                }
+                Scaffold(modifier = Modifier.fillMaxSize()) {
+                    HomeScreen(viewModel)
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    GameHubTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/gamehub/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/gamehub/ui/HomeScreen.kt
@@ -1,0 +1,67 @@
+package com.example.gamehub.ui
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.launch
+
+@Composable
+fun HomeScreen(viewModel: HomeViewModel) {
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val isOffline by viewModel.isOffline.collectAsState()
+
+    val refreshState = rememberPullRefreshState(
+        refreshing = false,
+        onRefresh = {
+            if (isOffline) {
+                Toast.makeText(context, "Невозможно обновить без сети", Toast.LENGTH_SHORT).show()
+            } else {
+                scope.launch {
+                    // trigger refresh here
+                }
+            }
+        }
+    )
+
+    LaunchedEffect(isOffline) {
+        if (isOffline) {
+            snackbarHostState.showSnackbar("Offline mode")
+        } else {
+            snackbarHostState.currentSnackbarData?.dismiss()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .pullRefresh(refreshState)
+        ) {
+            // Placeholder content
+            Text("Home", Modifier.align(Alignment.Center))
+            PullRefreshIndicator(false, refreshState, Modifier.align(Alignment.TopCenter))
+        }
+    }
+}

--- a/app/src/main/java/com/example/gamehub/ui/HomeViewModel.kt
+++ b/app/src/main/java/com/example/gamehub/ui/HomeViewModel.kt
@@ -1,0 +1,17 @@
+package com.example.gamehub.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.gamehub.util.NetworkManager
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+class HomeViewModel(
+    networkManager: NetworkManager,
+) : ViewModel() {
+    val isOffline: StateFlow<Boolean> = networkManager.isConnected
+        .map { connected -> !connected }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+}

--- a/app/src/main/java/com/example/gamehub/util/NetworkManager.kt
+++ b/app/src/main/java/com/example/gamehub/util/NetworkManager.kt
@@ -1,0 +1,37 @@
+package com.example.gamehub.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class NetworkManager(context: Context) {
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val _isConnected = MutableStateFlow(checkConnected())
+    val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+
+    private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            _isConnected.value = true
+        }
+
+        override fun onLost(network: Network) {
+            _isConnected.value = checkConnected()
+        }
+    }
+
+    init {
+        connectivityManager.registerDefaultNetworkCallback(callback)
+    }
+
+    private fun checkConnected(): Boolean {
+        val network = connectivityManager.activeNetwork ?: return false
+        val caps = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-pullrefresh = { group = "androidx.compose.material", name = "pullrefresh" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
## Summary
- add `NetworkManager` to monitor connectivity
- expose offline state via `HomeViewModel`
- add `HomeScreen` with snackbar banner and pull-to-refresh
- integrate new screen into `MainActivity`
- configure Compose pullrefresh dependency

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d346d7608328b55b287f8ffe4e0d